### PR TITLE
fix: Make the core feature work

### DIFF
--- a/src/lfu/tinylfu/bloom.rs
+++ b/src/lfu/tinylfu/bloom.rs
@@ -50,7 +50,6 @@ fn calc_size_by_wrong_positives(num_entries: f64, wrongs: f64) -> EntriesLocs {
 pub(crate) struct Bloom {
     bitset: Vec<u64>,
     elem_num: u64,
-    size_exp: u64,
     size: u64,
     set_locs: u64,
     shift: u64,
@@ -75,26 +74,15 @@ impl Bloom {
             bitset: vec![0; (size.size >> 6) as usize],
             elem_num: 0,
             size: size.size - 1,
-            size_exp: size.exp,
             set_locs: entries_locs.locs,
             shift: 64 - size.exp,
         };
         this
     }
 
-    /// `size` makes Bloom filter with as bitset of size sz.
-    pub fn size(&mut self, sz: usize) {
-        self.bitset = vec![0; sz >> 6]
-    }
-
     /// `reset` resets the `Bloom` filter
     pub fn reset(&mut self) {
         self.bitset.iter_mut().for_each(|v| *v = 0);
-    }
-
-    /// Returns the exp of the size
-    pub fn size_exp(&self) -> u64 {
-        self.size_exp
     }
 
     /// `clear` clear the `Bloom` filter
@@ -156,13 +144,6 @@ impl Bloom {
             self.add(hash);
             true
         }
-    }
-
-    /// `total_size` returns the total size of the bloom filter.
-    pub fn total_size(&self) -> usize {
-        // The bl struct has 5 members and each one is 8 byte. The bitset is a
-        // uint64 byte slice.
-        self.bitset.len() * 8 + 5 * 8
     }
 }
 

--- a/src/lfu/tinylfu/sketch/count_min_sketch_core.rs
+++ b/src/lfu/tinylfu/sketch/count_min_sketch_core.rs
@@ -3,12 +3,13 @@
 //! This file is a mechanical translation of the reference Golang code, available at https://github.com/dgryski/go-tinylfu/blob/master/cm4.go
 //!
 //! I claim no additional copyright over the original implementation.
-use crate::lfu::tinylfu::sketch::{DEPTH, next_power_of_2, CountMinRow};
 use crate::lfu::tinylfu::error::TinyLFUError;
-use alloc::vec::Vec;
-use alloc::vec;
-use core::ops::{Index, IndexMut};
+use crate::lfu::tinylfu::sketch::{next_power_of_2, CountMinRow, DEPTH};
 
+#[cfg(feature = "std")]
+use alloc::vec::{self, Vec};
+#[cfg(feature = "std")]
+use core::ops::{Index, IndexMut};
 
 /// `CountMinSketch` is a small conservative-update count-min sketch
 /// implementation with 4-bit counters
@@ -26,9 +27,13 @@ impl CountMinSketch {
         let ctrs = next_power_of_2(ctrs);
         let hctrs = ctrs / 2;
 
-
-        let this  = Self {
-            rows: [CountMinRow::new(hctrs), CountMinRow::new(hctrs), CountMinRow::new(hctrs), CountMinRow::new(hctrs)],
+        let this = Self {
+            rows: [
+                CountMinRow::new(hctrs),
+                CountMinRow::new(hctrs),
+                CountMinRow::new(hctrs),
+                CountMinRow::new(hctrs),
+            ],
             mask: ctrs - 1,
         };
 
@@ -44,10 +49,9 @@ impl CountMinSketch {
             let pos = (h + idx * l) & mask;
             row.increment(pos);
         });
-
     }
 
-    pub(crate) fn estimate(&self, key_hash: u64) -> u8 {
+    pub(crate) fn estimate(&self, key_hash: u64) -> u64 {
         let h = key_hash;
         let l = key_hash >> 32;
 
@@ -60,20 +64,21 @@ impl CountMinSketch {
                 min = v;
             }
         });
-        min
+        min.into()
     }
 
     pub(crate) fn reset(&mut self) {
         self.rows.iter_mut().for_each(|row| row.reset())
     }
-}
 
+    pub(crate) fn clear(&mut self) {
+        self.rows.iter_mut().for_each(|row| row.clear())
+    }
+}
 
 #[cfg(test)]
 mod test {
     use crate::lfu::tinylfu::sketch::CountMinSketch;
-
-
 
     #[test]
     fn test_count_min_sketch() {


### PR DESCRIPTION
Updating the support for the core feature to compile and be compatible on the API.

Also deletes some unused fields and methods the compiler was complaining about and cargo-fmt made some changes to the edited files.

We don't particularly need the core feature, however it is the only way to use the crate without depending on default features of the `chrono` crate.  And the chrono crate has a dependency on a vulnerable version of the time crate.  Switching to the core feature for this crate allows us to avoid having the vulnerability in our dependencies.