### PR TITLE
Fix RUSTSEC-2020-0071 by using std timestamp instead of chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ harness = false
 
 [features]
 default = ["std"]
-std = ["rand", "rand/std", "rand/std_rng", "chrono/default"]
+std = ["rand", "rand/std", "rand/std_rng"]
 core = ["hashbrown", "rand"]
 nightly = ["std", "rand/nightly"]
 nightly-core = ["core", "hashbrown/nightly"]
@@ -42,7 +42,6 @@ nightly-core = ["core", "hashbrown/nightly"]
 [dependencies]
 hashbrown = {version = "0.11.2", optional = true}
 rand = {version = "0.8.4", optional = true}
-chrono = {version = "0.4", optional = true, default-features = false}
 
 [dev-dependencies]
 scoped_threadpool = "0.1.*"

--- a/src/lfu/tinylfu/sketch/count_min_sketch_std.rs
+++ b/src/lfu/tinylfu/sketch/count_min_sketch_std.rs
@@ -3,12 +3,12 @@
 //! This file is a mechanical translation of the reference Golang code, available at https://github.com/dgraph-io/ristretto/blob/master/sketch.go
 //!
 //! I claim no additional copyright over the original implementation.
-use crate::lfu::tinylfu::sketch::{next_power_of_2, DEPTH, CountMinRow};
-use alloc::vec::Vec;
-use rand::{rngs::StdRng, SeedableRng, Rng};
-use chrono::{Utc};
-use crate::lfu::tinylfu::error::TinyLFUError;
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::lfu::tinylfu::error::TinyLFUError;
+use crate::lfu::tinylfu::sketch::{next_power_of_2, CountMinRow, DEPTH};
+use alloc::vec::Vec;
+use rand::{rngs::StdRng, Rng, SeedableRng};
 
 /// `CountMinSketch` is a small conservative-update count-min sketch
 /// implementation with 4-bit counters
@@ -27,7 +27,10 @@ impl CountMinSketch {
         let ctrs = next_power_of_2(ctrs);
         let hctrs = ctrs / 2;
 
-        let mut source = StdRng::seed_from_u64(Utc::now().timestamp_nanos().unsigned_abs());
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before Unix epoch");
+        let mut source = StdRng::seed_from_u64(timestamp.as_nanos() as u64);
 
         let seeds: Vec<u64> = {
             (0..DEPTH).map(|_| {


### PR DESCRIPTION
Those two different methods actually produce the same number, replacing `chrono` since cargo-audit reported its vulnerability.
<img width="514" alt="image" src="https://github.com/al8n/caches-rs/assets/62228055/b9ac5fd6-2f97-4ad7-b2dc-c5f2001dedd9">
