### PR TITLE
Make WTinyLFU / TinyLFU clonable

### DIFF
--- a/src/lfu/tinylfu.rs
+++ b/src/lfu/tinylfu.rs
@@ -139,6 +139,19 @@ impl<K: Hash + Eq> TinyLFU<K> {
     }
 }
 
+impl<K: Clone, KH: Clone> Clone for TinyLFU<K, KH> {
+    fn clone(&self) -> Self {
+        Self {
+            ctr: self.ctr.clone(),
+            doorkeeper: self.doorkeeper.clone(),
+            samples: self.samples,
+            w: self.w,
+            kh: self.kh.clone(),
+            marker: self.marker,
+        }
+    }
+}
+
 impl<K: Hash + Eq, KH: KeyHasher<K>> TinyLFU<K, KH> {
     /// Returns a TinyLFU according to the [`TinyLFUBuilder`]
     ///
@@ -418,6 +431,26 @@ mod test {
         l.increment_hashed_key(1);
         assert!(!l.doorkeeper.contains(1));
         assert_eq!(l.ctr.estimate(1), 1);
+    }
+
+    #[test]
+    fn test_clone() {
+        let mut l: TinyLFU<u64> = TinyLFU::new(4, 4, 0.01).unwrap();
+        l.increment_hashed_key(1);
+        l.increment_hashed_key(1);
+        l.increment_hashed_key(1);
+
+        assert!(l.doorkeeper.contains(1));
+        assert_eq!(l.ctr.estimate(1), 2);
+
+        let cloned = l.clone();
+
+        l.increment_hashed_key(1);
+        assert!(!l.doorkeeper.contains(1));
+        assert_eq!(l.ctr.estimate(1), 1);
+
+        assert!(cloned.doorkeeper.contains(1));
+        assert_eq!(cloned.ctr.estimate(1), 2);
     }
 
     // TODO: fix the bug caused by random

--- a/src/lfu/tinylfu/bloom.rs
+++ b/src/lfu/tinylfu/bloom.rs
@@ -46,6 +46,7 @@ fn calc_size_by_wrong_positives(num_entries: usize, wrongs: f64) -> EntriesLocs 
 }
 
 /// Bloom filter
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Bloom {
     bitset: Vec<u64>,

--- a/src/lfu/tinylfu/sketch/count_min_row.rs
+++ b/src/lfu/tinylfu/sketch/count_min_row.rs
@@ -10,6 +10,7 @@ use alloc::vec::Vec;
 use core::fmt::{Debug, Formatter};
 use core::ops::{Index, IndexMut};
 
+#[derive(Clone)]
 pub(crate) struct CountMinRow(Vec<u8>);
 
 impl CountMinRow {

--- a/src/lfu/tinylfu/sketch/count_min_sketch_std.rs
+++ b/src/lfu/tinylfu/sketch/count_min_sketch_std.rs
@@ -12,6 +12,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 
 /// `CountMinSketch` is a small conservative-update count-min sketch
 /// implementation with 4-bit counters
+#[derive(Clone)]
 pub(crate) struct CountMinSketch {
     rows: [CountMinRow; DEPTH],
     seeds: [u64; DEPTH],

--- a/src/lfu/wtinylfu.rs
+++ b/src/lfu/wtinylfu.rs
@@ -652,6 +652,24 @@ impl<K: Hash + Eq, V, KH: KeyHasher<K>, FH: BuildHasher, RH: BuildHasher, WH: Bu
     }
 }
 
+impl<
+        K: Hash + Eq + Clone,
+        V: Clone,
+        KH: KeyHasher<K> + Clone,
+        FH: BuildHasher + Clone,
+        RH: BuildHasher + Clone,
+        WH: BuildHasher + Clone,
+    > Clone for WTinyLFUCache<K, V, KH, FH, RH, WH>
+{
+    fn clone(&self) -> Self {
+        Self {
+            tinylfu: self.tinylfu.clone(),
+            lru: self.lru.clone(),
+            slru: self.slru.clone(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::lfu::WTinyLFUCache;
@@ -740,5 +758,23 @@ mod test {
 
         assert_eq!(cache.remove(&3), Some(33));
         assert_eq!(cache.remove(&2), Some(22));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_wtinylfu_clone() {
+        let mut cache = WTinyLFUCache::with_sizes(1, 2, 2, 5).unwrap();
+        assert_eq!(cache.cap(), 5);
+        assert_eq!(cache.window_cache_cap(), 1);
+        assert_eq!(cache.main_cache_cap(), 4);
+
+        assert_eq!(cache.put(1, 1), PutResult::Put);
+        assert!(cache.contains(&1));
+        assert_eq!(cache.put(2, 2), PutResult::Put);
+        assert!(cache.contains(&2));
+        assert_eq!(cache.put(3, 3), PutResult::Put);
+        assert!(cache.contains(&3));
+
+        assert_eq!(cache.put(4, 3), PutResult::Evicted { key: 1, value: 1 });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@ cfg_std!(
 
 // Struct used to hold a reference to a key
 #[doc(hidden)]
+#[derive(Clone)]
 pub struct KeyRef<K> {
     k: *const K,
 }

--- a/src/lru/segmented.rs
+++ b/src/lru/segmented.rs
@@ -157,6 +157,19 @@ pub struct SegmentedCache<K, V, FH = DefaultHashBuilder, RH = DefaultHashBuilder
     protected: RawLRU<K, V, DefaultEvictCallback, FH>,
 }
 
+impl<K: Hash + Eq + Clone, V: Clone, FH: BuildHasher + Clone, RH: BuildHasher + Clone> Clone
+    for SegmentedCache<K, V, FH, RH>
+{
+    fn clone(&self) -> Self {
+        Self {
+            probationary_size: self.probationary_size,
+            probationary: self.probationary.clone(),
+            protected_size: self.protected_size,
+            protected: self.protected.clone(),
+        }
+    }
+}
+
 impl<K: Hash + Eq, V> SegmentedCache<K, V> {
     /// Create a `SegmentedCache` with size and default configurations.
     pub fn new(probationary_size: usize, protected_size: usize) -> Result<Self, CacheError> {


### PR DESCRIPTION
Found myself in need of copy-on-write semantics for the cache but the lack of Clone makes that infeasible. This
adds Clone support to the cache provided that it's allowed for the generic implementation the structs are instantiated with.