### PR TITLE
readme: update no_std notes in readme; ci: add no_std test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,8 @@ jobs:
         key: ${{ runner.os }}-coverage-dotcargo
     - name: Run test
       run: cargo test
+    - name: Run test(no_std, hashbrown, libm)
+      run: cargo test --no-default-features --features hashbrown,libm
   
   sanitizer:
     name: sanitizer

--- a/README.md
+++ b/README.md
@@ -35,10 +35,14 @@ The MSRV for this crate is 1.55.0.
     [dependencies]
     caches = "0.2" 
     ```
-- no_std
+- no_std (before 0.2.8, it won't compile)
+
     ```toml
+    # when 0.2.9 is published
     [dependencies]
-    caches = {version: "0.2", default-features = false }
+    caches = {version = "0.2.9", default-features = false , features = ["hashbrown", "libm"]} 
+    # when 0.2.9 is **NOT** published 
+    caches = { git = "https://github.com/al8n/caches-rs.git", branch = "main", default-features = false, features = ["hashbrown", "libm"] }
     ```
 
 ## Usages

--- a/tea.yaml
+++ b/tea.yaml
@@ -1,0 +1,6 @@
+# https://tea.xyz/what-is-this-file
+---
+version: 1.0.0
+codeOwners:
+  - '0x7cc40A714f3b4572D8Ce05c5325aF8e5B6baB3ae'
+quorum: 1


### PR DESCRIPTION
### background
before(include) 0.2.8, it won't compile on no_std target with the following config:
```toml
caches = { version = "0.2.8" ,default-features = false, features = ["hashbrown"] }
```

since 0.2.9 is not published, the current work around is:
```toml
caches = { git = "https://github.com/al8n/caches-rs.git", branch = "main", default-features = false, features = ["hashbrown", "libm"] }
```

this should also be pointed out in readme
This pull request includes updates to the CI workflow and documentation to improve testing and clarify feature usage for the `caches` crate.

### CI Workflow Updates:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR173-R174): Added a new test step to run tests with `no_std`, `hashbrown`, and `libm` features enabled.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R45): Updated the `no_std` section to clarify the compilation requirements for versions before and after 0.2.8, and provided instructions for using the `hashbrown` and `libm` features with version 0.2.9 or the main branch from the repository.

### todo
- [ ] publish 0.2.9 so it can work with `no_std`