### PR TITLE
Fix/hashbrown version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,8 @@ jobs:
         key: ${{ runner.os }}-coverage-dotcargo
     - name: Run test
       run: cargo test
+    - name: Run test(no_std, hashbrown, libm)
+      run: cargo test --no-default-features --features hashbrown,libm
   
   sanitizer:
     name: sanitizer

--- a/README.md
+++ b/README.md
@@ -35,10 +35,14 @@ The MSRV for this crate is 1.55.0.
     [dependencies]
     caches = "0.2" 
     ```
-- no_std
+- no_std (before 0.2.8, it won't compile)
+
     ```toml
+    # when 0.2.9 is published
     [dependencies]
-    caches = {version: "0.2", default-features = false }
+    caches = {version = "0.2.9", default-features = false , features = ["hashbrown", "libm"]} 
+    # when 0.2.9 is **NOT** published 
+    caches = { git = "https://github.com/al8n/caches-rs.git", branch = "main", default-features = false, features = ["hashbrown", "libm"] }
     ```
 
 ## Usages

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ mod macros;
 
 cfg_not_std!(
     /// Re-export for DefaultHashBuilder
-    pub type DefaultHashBuilder = hashbrown::hash_map::DefaultHashBuilder;
+    pub type DefaultHashBuilder = hashbrown::DefaultHashBuilder;
 );
 
 cfg_std!(

--- a/tea.yaml
+++ b/tea.yaml
@@ -1,0 +1,6 @@
+# https://tea.xyz/what-is-this-file
+---
+version: 1.0.0
+codeOwners:
+  - '0x7cc40A714f3b4572D8Ce05c5325aF8e5B6baB3ae'
+quorum: 1


### PR DESCRIPTION
### background

hashbrown's  `DefaultHashBuilder` move to top level in v0.15

### fix

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L138-R138): Changed the type definition for `DefaultHashBuilder` to use `hashbrown::DefaultHashBuilder` instead of `hashbrown::hash_map::DefaultHashBuilder` for better consistency.